### PR TITLE
val -> lazy val

### DIFF
--- a/src/main/scala/kr/ac/kaist/jiset/phase/FilterMeta.scala
+++ b/src/main/scala/kr/ac/kaist/jiset/phase/FilterMeta.scala
@@ -104,8 +104,8 @@ case object FilterMeta extends PhaseObj[Unit, FilterMetaConfig, Unit] {
       "well-formed-json-stringify"
     )
 
-  val test262Dir = new File(s"$TEST_DIR/test262/test")
-  val allTests = TestList(
+  lazy val test262Dir = new File(s"$TEST_DIR/test262/test")
+  lazy val allTests = TestList(
     walkTree(test262Dir)
       .toList
       .filter(f => jsFilter(f.getName))


### PR DESCRIPTION
`FilterMeta`에서 test262 디렉토리를 `filter` 하는 코드가 `val`로 선언되어 있어 프로그램 시작 시에 매우 오래 걸리는 문제를 해결하였습니다.