### PR TITLE
Point .gitmodules to the correct ecma262 repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/kaist-plrg/ires
 [submodule "ecma262"]
 	path = ecma262
-	url = https://github.com/kaist-plrg/ecma262.git
+	url = https://github.com/tc39/ecma262
 [submodule "proposals"]
 	path = proposals
 	url = https://github.com/tc39/proposals


### PR DESCRIPTION
The currently linked ecma262 sub-module does not seem to exist.  
You probably meant to link the one by tc39.